### PR TITLE
Changes to mugen1/fight.def

### DIFF
--- a/data/gofx1280.def
+++ b/data/gofx1280.def
@@ -1,0 +1,11 @@
+﻿; This is a CommonFx file for ikemen. 
+; It's meant to handle some system fx and sfx (dizzy, guardbreak) outside of the default fightfx and common.snd to ensure backwards compatibility with preexisting mugen hitsparks.
+; If you're installing or developing your own fightfx, and it already includes custom animations for Ikemen's functions, you can disable this file from config.json. 
+[Info]
+prefix = GO; This prefix is to used instead of "F" when calling animations or sounds from this file.
+fx.scale = 4; for lifebars with a localcoord of 1280,720
+
+[Files]
+sff = gofx.sff; A copy of the default fightfx.sff
+air = gofx.air; A copy of the default fighfx.air, with some animations taken out.
+snd = gofx.snd; A copy of the default common.snd

--- a/data/mugen1/fight.def
+++ b/data/mugen1/fight.def
@@ -36,7 +36,7 @@ font4 = num1.def
 fightfx.sff = fightfx.sff
 fightfx.air = fightfx.air
 common.snd = common.snd
-fx1 = gofx.def; new ikemen fx
+fx1 = gofx1280.def; new ikemen fx
 ;-----------------------------------------------------------
 [FightFx]
 scale = 4


### PR DESCRIPTION
Very minor update to the default lifebar in `mugen1/` including a new commonfx file.

The current gofx.def file only works for lifebars with a localcoord of 320,240, so unless (until?) a localcoord function for commonfx is implemented, the default lifebar in the `mugen1`/ folder has comically mismatched special effects. 

(I should've included this in the previous PR...)